### PR TITLE
[FIX] more robust url matching and soft fail

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,3 +1,7 @@
+const prev = window.__odooIgnoreMissingDependencies;
+window.__odooIgnoreMissingDependencies = true;
+
+// Begin generated OWL code
 odoo.define('@odoo_confirm_module/core/common/composer_patch', ['@web/core/utils/patch', '@mail/core/common/composer', '@web/core/confirmation_dialog/confirmation_dialog', '@web/views/view_button/view_button', '@web/core/registry'], function (require) {
     'use strict';
     let __exports = {};
@@ -57,3 +61,6 @@ odoo.define('@odoo_confirm_module/core/common/composer_patch', ['@web/core/utils
     }
     return __exports;
 });
+// End generated OWL code
+
+window.__odooIgnoreMissingDependencies = prev;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Odoo Confirm",
   "description": "Asks you to confirm before sending a message in Odoo.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "manifest_version": 3,
   "action": {
     "default_icon": "icon.png"
@@ -16,14 +16,13 @@
     {
       "world": "MAIN",
       "matches": [
-        "*://*.odoo.com/odoo*",
-        "*://*.odoo.com/web*"
+        "*://*.odoo.com/odoo/*",
+        "*://*.odoo.com/web/*"
       ],
       "exclude_matches": [
         "*://*.odoo.com/odoo/login*",
         "*://*.odoo.com/web/login*",
-        "*://mergebot.odoo.com/*",
-        "*://*.odoo.com/odoo-sh*"
+        "*://mergebot.odoo.com/*"
       ],
       "js": [
         "content.js"


### PR DESCRIPTION
- Added a '/' to match the exact url segment for /odoo/ and /web/, avoids issues with /odoo-sh and /odoo-enterprise urls.
- Using __odooIgnoreMissingDependencies to fail silently on any other urls that do get matched, similar to the previous behavior on Odoo <16.0.

Fixes #8