### PR TITLE
[IMP] add domain filtering option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ _(Don't forget to refresh any existing Odoo tabs)_
 When the extension is installed & active, the following confirmation dialog will pop up whenever you send a message:
 ![image](https://github.com/user-attachments/assets/4ad44b6a-cc22-4262-ab80-8f0de9f9b005)
 
+## Options
+You can optionally restrict the confirmation to specific domains. Right-click the extension icon → **Options** (or go to your browser's extension settings) to:
+- Enable/disable domain filtering
+- Choose between **Whitelist** (confirmation only on listed domains) and **Blacklist** (confirmation everywhere except listed domains)
+- Manage your domain list (supports wildcards like `*.odoo.com`)
+
+When filtering is disabled, the extension works on all Odoo instances as usual.
+
 ## Development
 Chrome:
 1. Clone this repository.

--- a/content.js
+++ b/content.js
@@ -1,4 +1,8 @@
 function loadOdooConfirm() {
+    if (document.documentElement.dataset.odooConfirmActive === 'false') {
+        return;
+    }
+
     const version = window.odoo?.info?.server_version?.replace(/\+e$/, '');
     if (!version) {
         return;

--- a/domain-checker.js
+++ b/domain-checker.js
@@ -1,0 +1,10 @@
+(async () => {
+    try {
+        const settings = await getFilterSettings();
+        const currentDomain = window.location.hostname;
+        const active = DomainFilter.shouldActivateConfirmation(currentDomain, settings);
+        document.documentElement.dataset.odooConfirmActive = active ? "true" : "false";
+    } catch (e) {
+        document.documentElement.dataset.odooConfirmActive = "true";
+    }
+})();

--- a/domain-filter.js
+++ b/domain-filter.js
@@ -1,0 +1,57 @@
+const DomainFilter = (() => {
+    function normalizeDomain(input) {
+        if (!input || typeof input !== "string") return "";
+        let cleaned = input.trim();
+        cleaned = cleaned.replace(/^[a-zA-Z]+:\/\//, "");
+        cleaned = cleaned.split(/[/?#]/)[0];
+        cleaned = cleaned.split(":")[0];
+        cleaned = cleaned.replace(/\.+$/, "");
+        return cleaned.toLowerCase();
+    }
+
+    function matchesDomain(currentDomain, pattern) {
+        if (!currentDomain || !pattern) return false;
+
+        const current = currentDomain.toLowerCase().trim();
+        const base = pattern.toLowerCase().trim();
+
+        if (base.startsWith("*.")) {
+            const suffix = base.slice(2);
+            return current === suffix || current.endsWith("." + suffix);
+        }
+
+        return current === base || current === "www." + base;
+    }
+
+    function isValidDomain(domain) {
+        if (!domain || typeof domain !== "string") return false;
+        const trimmed = domain.trim();
+        if (trimmed.length === 0 || trimmed.length > 253) return false;
+        const pattern = /^(\*\.)?([a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\.)*[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
+        return pattern.test(trimmed);
+    }
+
+    function shouldActivateConfirmation(currentDomain, settings) {
+        if (!settings || !settings.filterEnabled) return true;
+        if (!Array.isArray(settings.domains) || settings.domains.length === 0) {
+            return settings.filterMode === "blacklist";
+        }
+
+        const domainInList = settings.domains.some((pattern) => matchesDomain(currentDomain, pattern));
+
+        return settings.filterMode === "whitelist" ? domainInList : !domainInList;
+    }
+
+    function isDuplicate(domain, existingDomains) {
+        const normalized = domain.toLowerCase().trim();
+        return existingDomains.some((d) => d.toLowerCase().trim() === normalized);
+    }
+
+    return {
+        normalizeDomain,
+        matchesDomain,
+        isValidDomain,
+        shouldActivateConfirmation,
+        isDuplicate,
+    };
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Odoo Confirm",
   "description": "Asks you to confirm before sending a message in Odoo.",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "manifest_version": 3,
   "action": {
     "default_icon": "icon.png"
@@ -12,7 +12,23 @@
     "48": "icon.png",
     "128": "icon.png"
   },
+  "permissions": ["storage"],
+  "options_ui": {
+    "page": "options/options.html",
+    "open_in_tab": true
+  },
   "content_scripts": [
+    {
+      "matches": [
+        "https://*/odoo*"
+      ],
+      "js": [
+        "storage.js",
+        "domain-filter.js",
+        "domain-checker.js"
+      ],
+      "run_at": "document_start"
+    },
     {
       "world": "MAIN",
       "matches": [

--- a/options/options.css
+++ b/options/options.css
@@ -1,0 +1,366 @@
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: #f0f2f5;
+    color: #1a1a2e;
+    line-height: 1.5;
+    min-height: 100vh;
+    padding: 40px 20px;
+}
+
+.container {
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+header {
+    text-align: center;
+    margin-bottom: 28px;
+}
+
+header h1 {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #1a1a2e;
+}
+
+.subtitle {
+    color: #6b7280;
+    font-size: 0.95rem;
+    margin-top: 4px;
+}
+
+.card {
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.06);
+    padding: 24px;
+}
+
+.setting-row {
+    padding: 12px 0;
+}
+
+.setting-row + .setting-row {
+    border-top: 1px solid #f0f0f0;
+}
+
+/* Toggle switch */
+
+.toggle-label {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    cursor: pointer;
+    user-select: none;
+}
+
+.label-text {
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.toggle-input {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.toggle-switch {
+    position: relative;
+    width: 44px;
+    height: 24px;
+    background: #d1d5db;
+    border-radius: 12px;
+    transition: background 0.2s ease;
+    flex-shrink: 0;
+}
+
+.toggle-switch::after {
+    content: "";
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 18px;
+    height: 18px;
+    background: #fff;
+    border-radius: 50%;
+    transition: transform 0.2s ease;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+}
+
+.toggle-input:checked + .toggle-switch {
+    background: #714B67;
+}
+
+.toggle-input:checked + .toggle-switch::after {
+    transform: translateX(20px);
+}
+
+.toggle-input:focus-visible + .toggle-switch {
+    outline: 2px solid #714B67;
+    outline-offset: 2px;
+}
+
+/* Filter options */
+
+.filter-options {
+    transition: opacity 0.2s ease;
+}
+
+.filter-options.disabled {
+    opacity: 0.4;
+    pointer-events: none;
+}
+
+/* Radio buttons */
+
+.mode-selection .label-text {
+    margin-bottom: 8px;
+    display: block;
+}
+
+.radio-group {
+    display: flex;
+    gap: 24px;
+}
+
+.radio-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 500;
+    user-select: none;
+}
+
+.radio-label input[type="radio"] {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.radio-mark {
+    position: relative;
+    width: 18px;
+    height: 18px;
+    border: 2px solid #d1d5db;
+    border-radius: 50%;
+    transition: border-color 0.15s ease;
+    flex-shrink: 0;
+}
+
+.radio-mark::after {
+    content: "";
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #714B67;
+    transform: scale(0);
+    transition: transform 0.15s ease;
+}
+
+.radio-label input[type="radio"]:checked + .radio-mark {
+    border-color: #714B67;
+}
+
+.radio-label input[type="radio"]:checked + .radio-mark::after {
+    transform: scale(1);
+}
+
+.radio-label input[type="radio"]:focus-visible + .radio-mark {
+    outline: 2px solid #714B67;
+    outline-offset: 2px;
+}
+
+/* Help box */
+
+.help-box {
+    background: #f8f7fc;
+    border-left: 3px solid #714B67;
+    border-radius: 0 6px 6px 0;
+    padding: 10px 14px;
+    margin: 12px 0 4px;
+}
+
+.help-box p {
+    font-size: 0.85rem;
+    color: #4b5563;
+    line-height: 1.5;
+}
+
+/* Domain section */
+
+.domain-section {
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px solid #f0f0f0;
+}
+
+.domain-section h2 {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 12px;
+}
+
+.domain-input-row {
+    display: flex;
+    gap: 8px;
+}
+
+.domain-input-row input {
+    flex: 1;
+    padding: 8px 12px;
+    border: 1px solid #d1d5db;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-family: inherit;
+    outline: none;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.domain-input-row input:focus {
+    border-color: #714B67;
+    box-shadow: 0 0 0 3px rgba(113, 75, 155, 0.12);
+}
+
+.domain-input-row input.input-error {
+    border-color: #ef4444;
+    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.1);
+}
+
+.domain-input-row button {
+    padding: 8px 20px;
+    background: #714B67;
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+    transition: background 0.15s ease;
+    white-space: nowrap;
+}
+
+.domain-input-row button:hover {
+    background: #7b4775;
+}
+
+.domain-input-row button:active {
+    background: #4a2f6e;
+}
+
+.domain-input-row button:focus-visible {
+    outline: 2px solid #714B67;
+    outline-offset: 2px;
+}
+
+.error-text {
+    color: #ef4444;
+    font-size: 0.82rem;
+    margin-top: 6px;
+}
+
+/* Domain list */
+
+.domain-list {
+    list-style: none;
+    margin-top: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.domain-list .empty-state {
+    text-align: center;
+    color: #9ca3af;
+    font-size: 0.88rem;
+    padding: 20px 0;
+}
+
+.domain-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    transition: background 0.1s ease;
+}
+
+.domain-item:hover {
+    background: #f3f4f6;
+}
+
+.domain-item-text {
+    font-size: 0.9rem;
+    font-family: "SF Mono", SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+    color: #374151;
+    word-break: break-all;
+}
+
+.domain-remove-btn {
+    background: none;
+    border: none;
+    color: #9ca3af;
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: color 0.15s ease, background 0.15s ease;
+    flex-shrink: 0;
+    margin-left: 8px;
+    font-size: 1.1rem;
+    line-height: 1;
+}
+
+.domain-remove-btn:hover {
+    color: #ef4444;
+    background: rgba(239, 68, 68, 0.08);
+}
+
+.domain-remove-btn:focus-visible {
+    outline: 2px solid #ef4444;
+    outline-offset: 1px;
+}
+
+/* Footer & status */
+
+footer {
+    text-align: center;
+    margin-top: 16px;
+    min-height: 24px;
+}
+
+.status-message {
+    font-size: 0.85rem;
+    color: #059669;
+    font-weight: 500;
+    animation: fadeIn 0.2s ease;
+}
+
+.status-message.error {
+    color: #ef4444;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(-4px); }
+    to { opacity: 1; transform: translateY(0); }
+}

--- a/options/options.html
+++ b/options/options.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Odoo Confirm – Options</title>
+    <link rel="stylesheet" href="options.css">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Odoo Confirm 😺</h1>
+            <p class="subtitle">Asks you to confirm before sending a message in Odoo</p>
+        </header>
+
+        <section class="card">
+            <div class="setting-row">
+                <label class="toggle-label" for="filter-enabled">
+                    <span class="label-text">Enable domain filtering</span>
+                    <input type="checkbox" id="filter-enabled" class="toggle-input">
+                    <span class="toggle-switch"></span>
+                </label>
+            </div>
+
+            <div id="filter-options" class="filter-options disabled">
+                <div class="setting-row mode-selection">
+                    <span class="label-text">Filter mode</span>
+                    <div class="radio-group">
+                        <label class="radio-label">
+                            <input type="radio" name="filter-mode" value="whitelist" checked>
+                            <span class="radio-mark"></span>
+                            Whitelist
+                        </label>
+                        <label class="radio-label">
+                            <input type="radio" name="filter-mode" value="blacklist">
+                            <span class="radio-mark"></span>
+                            Blacklist
+                        </label>
+                    </div>
+                </div>
+
+                <div class="help-box" id="mode-help">
+                    <p id="help-text">
+                        <strong>Whitelist:</strong> Confirmation will only appear on the domains listed below
+                    </p>
+                </div>
+
+                <div class="domain-section">
+                    <h2>Domains</h2>
+                    <div class="domain-input-row">
+                        <input
+                            type="text"
+                            id="domain-input"
+                            placeholder="e.g. mycompany.odoo.com or *.odoo.com"
+                            autocomplete="off"
+                            spellcheck="false"
+                        >
+                        <button id="add-domain-btn" type="button">Add</button>
+                    </div>
+                    <p id="domain-error" class="error-text" hidden></p>
+
+                    <ul id="domain-list" class="domain-list">
+                        <li class="empty-state">No domains added yet</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <footer>
+            <span id="status-message" class="status-message" hidden></span>
+        </footer>
+    </div>
+
+    <script src="../storage.js"></script>
+    <script src="../domain-filter.js"></script>
+    <script src="options.js"></script>
+</body>
+</html>

--- a/options/options.js
+++ b/options/options.js
@@ -1,0 +1,167 @@
+document.addEventListener("DOMContentLoaded", async () => {
+    const filterEnabledCheckbox = document.getElementById("filter-enabled");
+    const filterOptionsDiv = document.getElementById("filter-options");
+    const modeRadios = document.querySelectorAll('input[name="filter-mode"]');
+    const domainInput = document.getElementById("domain-input");
+    const addDomainBtn = document.getElementById("add-domain-btn");
+    const domainError = document.getElementById("domain-error");
+    const domainList = document.getElementById("domain-list");
+    const helpText = document.getElementById("help-text");
+    const statusMessage = document.getElementById("status-message");
+
+    let currentSettings = null;
+    const debouncedSave = createDebouncedSave(400);
+    let statusTimer = null;
+
+    const HELP_TEXTS = {
+        whitelist: "<strong>Whitelist:</strong> Confirmation will only appear on the domains listed below",
+        blacklist: "<strong>Blacklist:</strong> Confirmation will appear everywhere <em>except</em> on the domains listed below",
+    };
+
+    function flashStatus(msg, isError = false) {
+        statusMessage.textContent = msg;
+        statusMessage.hidden = false;
+        statusMessage.classList.toggle("error", isError);
+        clearTimeout(statusTimer);
+        statusTimer = setTimeout(() => { statusMessage.hidden = true; }, 2000);
+    }
+
+    function onSaveDone(err) {
+        flashStatus(err ? "Failed to save settings" : "Settings saved", err);
+    }
+
+    function updateFilterOptionsState() {
+        filterOptionsDiv.classList.toggle("disabled", !currentSettings.filterEnabled);
+    }
+
+    function updateHelpText() {
+        helpText.innerHTML = HELP_TEXTS[currentSettings.filterMode];
+    }
+
+    function renderDomainList() {
+        domainList.innerHTML = "";
+
+        if (currentSettings.domains.length === 0) {
+            const li = document.createElement("li");
+            li.className = "empty-state";
+            li.textContent = "No domains added yet";
+            domainList.appendChild(li);
+            return;
+        }
+
+        for (const domain of currentSettings.domains) {
+            const li = document.createElement("li");
+            li.className = "domain-item";
+
+            const span = document.createElement("span");
+            span.className = "domain-item-text";
+            span.textContent = domain;
+
+            const btn = document.createElement("button");
+            btn.className = "domain-remove-btn";
+            btn.type = "button";
+            btn.title = "Remove " + domain;
+            btn.textContent = "\u2715";
+            btn.setAttribute("aria-label", "Remove " + domain);
+            btn.addEventListener("click", () => removeDomain(domain));
+
+            li.appendChild(span);
+            li.appendChild(btn);
+            domainList.appendChild(li);
+        }
+    }
+
+    function showDomainError(msg) {
+        domainError.textContent = msg;
+        domainError.hidden = false;
+        domainInput.classList.add("input-error");
+    }
+
+    function clearDomainError() {
+        domainError.hidden = true;
+        domainError.textContent = "";
+        domainInput.classList.remove("input-error");
+    }
+
+    function addDomain() {
+        const raw = domainInput.value.trim();
+
+        if (!raw) {
+            showDomainError("Please enter a domain");
+            return;
+        }
+
+        const domain = DomainFilter.normalizeDomain(raw);
+
+        if (!DomainFilter.isValidDomain(domain)) {
+            showDomainError('Invalid domain format. Use something like "mycompany.odoo.com" or "*.odoo.com"');
+            return;
+        }
+
+        if (DomainFilter.isDuplicate(domain, currentSettings.domains)) {
+            showDomainError("This domain is already in the list");
+            return;
+        }
+
+        clearDomainError();
+        currentSettings.domains.push(domain);
+        domainInput.value = "";
+        domainInput.focus();
+        renderDomainList();
+        saveImmediate();
+    }
+
+    function removeDomain(domain) {
+        currentSettings.domains = currentSettings.domains.filter((d) => d !== domain);
+        renderDomainList();
+        saveImmediate();
+    }
+
+    async function saveImmediate() {
+        try {
+            await saveFilterSettings(currentSettings);
+            onSaveDone(null);
+        } catch (e) {
+            onSaveDone(e);
+        }
+    }
+
+    function renderSettings() {
+        filterEnabledCheckbox.checked = currentSettings.filterEnabled;
+        updateFilterOptionsState();
+
+        for (const radio of modeRadios) {
+            radio.checked = radio.value === currentSettings.filterMode;
+        }
+        updateHelpText();
+        renderDomainList();
+    }
+
+    filterEnabledCheckbox.addEventListener("change", () => {
+        currentSettings.filterEnabled = filterEnabledCheckbox.checked;
+        updateFilterOptionsState();
+        debouncedSave(currentSettings, onSaveDone);
+    });
+
+    for (const radio of modeRadios) {
+        radio.addEventListener("change", () => {
+            currentSettings.filterMode = radio.value;
+            updateHelpText();
+            debouncedSave(currentSettings, onSaveDone);
+        });
+    }
+
+    addDomainBtn.addEventListener("click", addDomain);
+
+    domainInput.addEventListener("keydown", (e) => {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            addDomain();
+        }
+    });
+
+    domainInput.addEventListener("input", clearDomainError);
+
+    currentSettings = await getFilterSettings();
+    renderSettings();
+});

--- a/storage.js
+++ b/storage.js
@@ -1,0 +1,37 @@
+const FILTER_DEFAULTS = {
+    filterEnabled: false,
+    filterMode: 'whitelist',
+    domains: []
+};
+
+const storageArea = chrome?.storage?.sync || globalThis.browser?.storage?.sync || null;
+
+async function getFilterSettings() {
+    if (!storageArea) return { ...FILTER_DEFAULTS };
+    try {
+        return await storageArea.get(FILTER_DEFAULTS);
+    } catch (e) {
+        console.error('😿 Odoo Confirm: failed to read settings', e);
+        return { ...FILTER_DEFAULTS };
+    }
+}
+
+async function saveFilterSettings(settings) {
+    if (!storageArea) throw new Error('Storage API not available');
+    await storageArea.set(settings);
+}
+
+function createDebouncedSave(delayMs = 400) {
+    let timer = null;
+    return (settings, onDone) => {
+        clearTimeout(timer);
+        timer = setTimeout(async () => {
+            try {
+                await saveFilterSettings(settings);
+                onDone?.(null);
+            } catch (e) {
+                onDone?.(e);
+            }
+        }, delayMs);
+    };
+}


### PR DESCRIPTION
Hello,

First of all, well done on the extension! It's very interesting how you implemented the feature :)

I recommend it to my BA colleagues and it has already saved them several times 😂 

I've had some feedback that it would be good if it only activated on our DB. Their main argument is that during demos, this "confuses" customers who think it's a built-in feature and wonder if it's mandatory to have it

So I thought that a feature that would allow whitelisting/blacklisting would be interesting to have a more granular choice for applying this confirmation. By default, it is disabled, so the behaviour remains the same

I chose to use an options page for the extension rather than a pop-up when the extension icon is clicked, as this seemed more logical given the purpose of the extension. This can of course be adjusted 

---

Matching logic 

| URL ↓ · Pattern → | `odoo.com` | `*.odoo.com` | `mycompany.odoo.com` | `*.mycompany.odoo.com` |
|---|:---:|:---:|:---:|:---:|
| `odoo.com` | ✅ | ✅ | ❌ | ❌ |
| `www.odoo.com` | ✅ | ✅ | ❌ | ❌ |
| `mycompany.odoo.com` | ❌ | ✅ | ✅ | ✅ |
| `www.mycompany.odoo.com` | ❌ | ✅ | ✅ | ✅ |
| `staging.mycompany.odoo.com` | ❌ | ✅ | ❌ | ✅ |
| `runbot136.odoo.com` | ❌ | ✅ | ❌ | ❌ |
| `deep.sub.odoo.com` | ❌ | ✅ | ❌ | ❌ |


---

Here's how it looks

### Feature disabled
<img width="2241" height="1349" alt="image" src="https://github.com/user-attachments/assets/42f411b6-130c-4ac0-ac8a-6ed3a0cbd357" />

### Whitelist mode
<img width="2238" height="1337" alt="image" src="https://github.com/user-attachments/assets/95eb4759-e256-4d42-8b0b-ddebbda1ca3c" />

### Blacklist mode
<img width="2239" height="1348" alt="image" src="https://github.com/user-attachments/assets/e6f7d18e-6e37-44d8-9a1b-d3e73ace22bb" />